### PR TITLE
Refactor after changes in zinolib adapters

### DIFF
--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -15,7 +15,7 @@ from zinolib.compat import StrEnum
 from zinolib.config.zino1 import ZinoV1Config
 
 from howitz.users.db import UserDB
-from howitz.users.utils import authenticate_user, update_token
+from howitz.users.utils import authenticate_user
 from .utils import login_check
 
 

--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -62,6 +62,8 @@ css.build()
 
 DB_URL = Path('howitz.sqlite3')
 database = UserDB(DB_URL)
+database.initdb()
+app.logger.info('Connected to database %s', database)
 
 config = ZinoV1Config.from_tcl('ritz.tcl')
 app.logger.debug('ZinoV1Config %s', config)
@@ -69,14 +71,10 @@ event_manager = Zino1EventManager.configure(config)
 app.logger.debug('Zino1EventManager %s', event_manager)
 
 
-def initialize_database():
-    database.initdb()
-    app.logger.info('Connected to database %s', database.connection)
-
-
 def connect_to_zino():
-    zino_session.connect()
-    app.logger.info('Connected to Zino %s', zino_session.connStatus)
+    event_manager.configure(config)
+    event_manager.connect()
+    app.logger.info('Connected to Zino %s', event_manager.is_connected)
 
 
 @login_manager.user_loader
@@ -89,8 +87,6 @@ def load_user(user_id):
 
 with app.app_context():
     expanded_events = []
-    initialize_database()
-    connect_to_zino()
 
 
 @login_manager.unauthorized_handler

--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -204,7 +204,7 @@ def get_event_details(id):
 
 @app.route('/')
 @app.route('/hello-world')
-@login_check(current_user, zino_session, unauthorized)
+@login_check(current_user, event_manager, unauthorized)
 def index():
     exemplify_loop = list('abracadabra')
     return render_template('index.html', example_list=exemplify_loop)
@@ -214,7 +214,7 @@ def index():
 def login():
     app.logger.debug('current user is authenticated %s', current_user.is_authenticated)
     try:
-        if current_user.is_authenticated and zino_session.authenticated:
+        if current_user.is_authenticated and event_manager.is_authenticated:
             default_url = flask.url_for('index')
             return flask.redirect(default_url)
     except:
@@ -228,7 +228,7 @@ def sign_in_form():
 
 
 @app.route('/events')
-@login_check(current_user, zino_session, unauthorized)
+@login_check(current_user, event_manager, unauthorized)
 def events():
     # current_app["expanded_events"] = []
     return render_template('/views/events.html')

--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -103,17 +103,18 @@ def unauthorized():
 
 
 def auth_handler(username, password):
+    # check user credentials in database
     user = authenticate_user(username, password)
-    if user:  # is authenticated
+    if user:  # is registered in database
         app.logger.debug('User %s', user)
 
-        update_token(user, zino_session.authChallenge, password)
-        zino_session.authenticate(user.username, password)
-        app.logger.debug('User connected to Zino %s', zino_session.connStatus)
+        connect_to_zino()
 
-        login_user(user)
-        flask.flash('Logged in successfully.')
-        return user
+        if event_manager.is_authenticated:  # is zino authenticated
+            app.logger.debug('User is Zino authenticated %s', event_manager.is_authenticated)
+            login_user(user)
+            flask.flash('Logged in successfully.')
+            return user
     return None
 
 

--- a/src/howitz/users/db.py
+++ b/src/howitz/users/db.py
@@ -54,13 +54,6 @@ class UserDB:
         self.connection.commit()
         return self.get(user.username)
 
-    def update_token(self, username, token):
-        querystring = "UPDATE user SET token=? where username=?"
-        params = (token, username)
-        self.cursor.execute(querystring, params)
-        self.connection.commit()
-        return self.get(username)
-
     def remove(self, username):
         querystring = "DELETE from user where username = ?"
         params = (username,)

--- a/src/howitz/users/utils.py
+++ b/src/howitz/users/utils.py
@@ -25,11 +25,3 @@ def encode_password(password: str):
 
 def verify_password(password: str, password_hash: str):
     return check_password_hash(password_hash, password)
-
-
-def update_token(user, challenge, secret):
-    # copied from ritz implementation
-    gen_token = "%s %s" % (challenge, secret)
-    auth_token = hashlib.sha1(gen_token.encode('UTF-8')).hexdigest()
-
-    endpoints.database.update_token(user.username, auth_token)

--- a/src/howitz/utils.py
+++ b/src/howitz/utils.py
@@ -1,7 +1,7 @@
 import functools
 
 
-def login_check(current_user, zino_session, fallback_func):
+def login_check(current_user, event_manager, fallback_func):
     """Check authentication status in both zino and flask session.
     """
 
@@ -9,7 +9,7 @@ def login_check(current_user, zino_session, fallback_func):
 
         @functools.wraps(func)
         def __login_check(*args):
-            if current_user.is_authenticated and zino_session.authenticated:
+            if current_user.is_authenticated and event_manager.is_authenticated:
                 return func(*args)
 
             return fallback_func(*args)


### PR DESCRIPTION
### Changes:
- drops talking to globals from app context
- drops all direct usage of Zino Adapters
- updates auth and unauth handling due to changes in Uninett/zinolib#25
- removes update token methods

### Extra attention needed:
- are globals handled properly?
- should ZinoV1EventManager be configured differently (f.e. not via tcl file)?

**NB!** Depends on Uninett/zinolib#25
Closes #24 