### PR TITLE
Handle errors on events fetch and poll

### DIFF
--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -92,10 +92,6 @@ def get_current_events():
             session["not_connected_counter"] += 1
             current_app.event_manager.get_events()
             pass
-    except Exception as exc:
-        current_app.logger.exception('An error occurred on events fetch')
-        show_error_popup(exc, 'An unexpected error occurred when fetching events')
-        raise
 
     events = current_app.event_manager.events
 
@@ -126,10 +122,6 @@ def poll_current_events():
             session["not_connected_counter"] += 1
             current_app.event_manager.get_events()
             pass
-    except Exception as exc:
-        current_app.logger.exception('An error occurred on events poll')
-        show_error_popup(exc, 'An unexpected error occurred when polling events')
-        raise
 
     events = current_app.event_manager.events
 

--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -85,10 +85,12 @@ def get_current_events():
         current_app.event_manager.get_events()
     except NotConnectedError as notConnErr:
         if session["not_connected_counter"] > 1:  # This error is not intermittent - increase counter and handle
+            current_app.logger.exception('Recurrent NotConnectedError %s', notConnErr)
             session["not_connected_counter"] += 1
             show_error_popup(notConnErr, 'An error occurred, please check your connection status to Zino')
             raise
         else:  # This error is intermittent - increase counter and retry
+            current_app.logger.exception('Intermittent NotConnectedError %s', notConnErr)
             session["not_connected_counter"] += 1
             current_app.event_manager.get_events()
             pass
@@ -115,10 +117,12 @@ def poll_current_events():
         current_app.event_manager.get_events()
     except NotConnectedError as notConnErr:
         if session["not_connected_counter"] > 1:  # This error is not intermittent - increase counter and handle
+            current_app.logger.exception('Recurrent NotConnectedError %s', notConnErr)
             session["not_connected_counter"] += 1
             show_error_popup(notConnErr, 'An error occurred, please check your connection status to Zino')
             raise
         else:  # This error is intermittent - increase counter and retry
+            current_app.logger.exception('Intermittent NotConnectedError %s', notConnErr)
             session["not_connected_counter"] += 1
             current_app.event_manager.get_events()
             pass
@@ -203,6 +207,7 @@ def get_event_attributes(id, res_format=dict):
     try:
         event = current_app.event_manager.create_event_from_id(int(id))
     except RetryError as retryErr:  # Intermittent error in Zino
+        current_app.logger.exception('RetryError when fetching event attributes %s', retryErr)
         show_error_popup(retryErr, 'Could not fetch event attributes, please retry')
         raise
 
@@ -220,6 +225,7 @@ def get_event_details(id):
     try:
         event_attr = vars(current_app.event_manager.create_event_from_id(int(id)))
     except RetryError as retryErr:  # Intermittent error in Zino
+        current_app.logger.exception('RetryError when fetching event details %s', retryErr)
         show_error_popup(retryErr, 'Could not fetch event details, please retry')
         raise
 

--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -202,31 +202,33 @@ def color_code_event(event):
 def get_event_attributes(id, res_format=dict):
     try:
         event = current_app.event_manager.create_event_from_id(int(id))
-        event_dict = vars(event)
-        attr_list = [f"{k}:{v}" for k, v in event_dict.items()]
-
-        # fixme is there a better way to do switch statements in Python?
-        return {
-            list: attr_list,
-            dict: event_dict,
-        }[res_format]
     except RetryError as retryErr:  # Intermittent error in Zino
         show_error_popup(retryErr, 'Could not fetch event attributes, please retry')
         raise
+
+    event_dict = vars(event)
+    attr_list = [f"{k}:{v}" for k, v in event_dict.items()]
+
+    # fixme is there a better way to do switch statements in Python?
+    return {
+        list: attr_list,
+        dict: event_dict,
+    }[res_format]
 
 
 def get_event_details(id):
     try:
         event_attr = vars(current_app.event_manager.create_event_from_id(int(id)))
-        event_logs = current_app.event_manager.get_log_for_id(int(id))
-        event_history = current_app.event_manager.get_history_for_id(int(id))
-
-        event_msgs = event_logs + event_history
-
-        return event_attr, event_logs, event_history, event_msgs
     except RetryError as retryErr:  # Intermittent error in Zino
         show_error_popup(retryErr, 'Could not fetch event details, please retry')
         raise
+
+    event_logs = current_app.event_manager.get_log_for_id(int(id))
+    event_history = current_app.event_manager.get_history_for_id(int(id))
+
+    event_msgs = event_logs + event_history
+
+    return event_attr, event_logs, event_history, event_msgs
 
 
 def show_error_popup(error, short_description):

--- a/src/howitz/templates/components/table/events-table.html
+++ b/src/howitz/templates/components/table/events-table.html
@@ -4,6 +4,7 @@
         hx-swap="innerHTML"
         hx-target="#eventlist-list"
         hx-trigger="load"
+        hx-target-error="body"
 >
     <thead class="text-xs text-center text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-300">
     <tr>

--- a/src/howitz/templates/views/events.html
+++ b/src/howitz/templates/views/events.html
@@ -18,6 +18,7 @@
                 hx-trigger="load"
                 role="status"
                 class="htmx-indicator animate-pulse"
+                hx-target-error="body"
         >
 
             <span class="sr-only">Loading Table...</span>


### PR DESCRIPTION
Depends on #42, #43

### Handles errors:

- RetryError on fetch of event attributes and on fetch of event history and logs (event details)
- NotConnected error number 2 or greater on events fetch. First NotConnected error promts automatic retry (workaround for #41)
- Generic Exception on events fetch or events poll (any other unexpected error)

In all cases (except first NotConnected error) an error popup is shown to user.