### PR TITLE
[BUG]: Footer fetches itself in an endless loop

### DIFF
--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -267,7 +267,7 @@ def index():
     return render_template('/views/events.html')
 
 
-@main.get('/footer.html')
+@main.get('/footer')
 def footer():
     tz = current_app.howitz_config["timezone"]  # Get raw string from config. Accepted values are 'UTC' or 'LOCAL'.
     if tz == 'LOCAL':  # Change to a specific timezone name if 'LOCAL'
@@ -275,7 +275,7 @@ def footer():
     elif not tz == DEFAULT_TIMEZONE:  # Fall back to default if invalid value is provided
         tz = f"{DEFAULT_TIMEZONE} (default)"
 
-    return render_template('/components/footer/footer.html', poll_interval=current_app.howitz_config["poll_interval"],
+    return render_template('/components/footer/footer-info.html', poll_interval=current_app.howitz_config["poll_interval"],
                            timezone=tz)
 
 

--- a/src/howitz/templates/components/footer/footer-info.html
+++ b/src/howitz/templates/components/footer/footer-info.html
@@ -1,0 +1,6 @@
+<p class="p-2 text-white text-semibold inline-block">
+    Updating every {{ poll_interval }}s.
+</p>
+<p class="p-2 text-white text-semibold inline-block">
+    Configured timezone is {{ timezone }}.
+</p>

--- a/src/howitz/templates/components/footer/footer.html
+++ b/src/howitz/templates/components/footer/footer.html
@@ -1,10 +1,5 @@
-<footer hx-get="/footer.html"
+<footer hx-get="/footer"
         hx-trigger="load"
+        hx-swap="innerHTML"
         class="bg-slate-950">
-    <p class="p-2 text-white text-semibold inline-block">
-        Updating every {{ poll_interval }}s.
-    </p>
-    <p class="p-2 text-white text-semibold inline-block">
-        Configured timezone is {{ timezone }}.
-    </p>
 </footer>


### PR DESCRIPTION
This was because of a trigger set to on 'load' and swap method set to 'outerHTML'. This combination made it so that on each fetch footer was replaced completely aka loaded anew, so load trigger was activated and footer refetch itself again.