### PR TITLE
Wipe out UI state on manual reload

### DIFF
--- a/src/howitz/endpoints.py
+++ b/src/howitz/endpoints.py
@@ -273,6 +273,7 @@ def get_event_details(id):
 @main.route('/events')
 @login_check()
 def index():
+    clear_ui_state()
     return render_template('/views/events.html')
 
 


### PR DESCRIPTION
Closes #100 

### Implemented changes:
Every time the events page is initially loaded, or manually reloaded, the UI state is cleared:
- checked (selected) rows become unchecked
- expanded rows collapse
- any existing error alerts are removed
- list with IDs of current events is cleared (not visible in the UI, related to NTIE table refresh in #87)