### PR TITLE
Show custom error page on 502 BadGateway

### DIFF
--- a/src/howitz/__init__.py
+++ b/src/howitz/__init__.py
@@ -13,7 +13,7 @@ from werkzeug.exceptions import HTTPException, BadRequest, NotFound, Forbidden
 from howitz.config.utils import load_config
 from howitz.config.zino1 import make_zino1_config
 from howitz.config.howitz import make_howitz_config
-from howitz.error_handlers import handle_generic_exception, handle_generic_http_exception, handle_400, handle_404, handle_403, handle_lost_connection
+from howitz.error_handlers import handle_generic_exception, handle_generic_http_exception, handle_400, handle_404, handle_403, handle_lost_connection, handle_bad_gateway
 from howitz.users.db import UserDB
 from howitz.users.commands import user_cli
 from zinolib.controllers.zino1 import Zino1EventManager, LostConnectionError, NotConnectedError
@@ -33,6 +33,7 @@ def create_app(test_config=None):
     app.register_error_handler(LostConnectionError, handle_lost_connection)
     app.register_error_handler(BrokenPipeError, handle_lost_connection)
     app.register_error_handler(NotConnectedError, handle_lost_connection)
+    app.register_error_handler(502, handle_bad_gateway)
 
     # load config
     app = load_config(app, test_config)

--- a/src/howitz/error_handlers.py
+++ b/src/howitz/error_handlers.py
@@ -2,7 +2,7 @@ import uuid
 
 from flask import render_template, session, current_app, make_response, request
 from flask_login import current_user
-from werkzeug.exceptions import HTTPException
+from werkzeug.exceptions import HTTPException, BadGateway
 
 from howitz.endpoints import connect_to_zino
 from howitz.utils import serialize_exception
@@ -77,6 +77,20 @@ def handle_403(e):
     response.headers['HX-Trigger'] = 'htmx:responseError'
 
     return response, 403
+
+
+def handle_bad_gateway(e):
+    current_app.logger.exception("502 Bad Gateway has occurred %s", e)
+    description = BadGateway.description
+    try:
+        description = e.description
+    except AttributeError:
+        pass
+
+    response = make_response(render_template('responses/502.html', err_msg=description))
+    response.headers['HX-Retarget'] = 'body'
+    response.headers['HX-Reswap'] = 'innerHTML'
+    return response, 502
 
 
 def handle_lost_connection(e):

--- a/src/howitz/templates/responses/502.html
+++ b/src/howitz/templates/responses/502.html
@@ -1,0 +1,11 @@
+{% block content %}
+    <main
+            class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6 bg-slate-900 text-sky-200/80"
+    >
+        <section class="mx-auto max-w-screen-sm text-center">
+            <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl">502</h1>
+            <p class="mb-4 text-3xl tracking-tight font-bold md:text-4xl">Bad Gateway</p>
+            <p class="mb-4 text-lg font-light text-teal-300">{{ err_msg }}</p>
+        </section>
+    </main>
+{% endblock %}


### PR DESCRIPTION
Closes #146 

Instead of prepending error message to an existing page, the whole page is re-swapped with a custom 502.html:

![Screenshot 2024-07-03 at 10 06 04](https://github.com/Uninett/Howitz/assets/60876078/32d4dc5c-7344-4fa3-8b3c-0cf8e89575f5)
